### PR TITLE
Convert type to atom when choosing a different database

### DIFF
--- a/lib/database/common.ex
+++ b/lib/database/common.ex
@@ -4,7 +4,7 @@ defmodule Plsm.Database.Common do
   """
   @spec create(Plsm.Common.Configs) :: Plsm.Database
   def create(configs) do
-    case configs.database[:type] do
+    case String.to_atom(configs.database[:type]) do
       :mysql -> IO.puts "Using MySql..."; Plsm.Database.create %Plsm.Database.MySql{}, configs
       :postgres -> IO.puts "Using PostgreSQL..."; Plsm.Database.create %Plsm.Database.PostgreSQL{}, configs
       _ -> IO.puts "Using default database MySql..."; Plsm.Database.create %Plsm.Database.MySql{}, configs

--- a/lib/plsm.ex
+++ b/lib/plsm.ex
@@ -58,7 +58,8 @@ use Mix.Task
         "#######################################################################################################################################################\n"
         <> "# Enter the database information for the DB you're connecting to. The driver version has to correspond to the ODBC driver version for your MySQL driver\n"
         <> "#######################################################################################################################################################\n\n"
-        <> "database = [\n" 
+        <> "database = [\n"
+        <> format_item("type", "your database type", ",")
         <> format_item("server", "localhost",",")
         <> format_item("port", "3306",",")
         <> format_item("database_name", "Name of database",",")


### PR DESCRIPTION
We need to convert the database type to atom when selecting a different one. the field came as string and Mysql is always selected.