### PR TITLE
Cleanup export, change the way schemas are generated

### DIFF
--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -1,22 +1,6 @@
 defmodule Plsm.IO.Export do
-   
-
-    @doc """
-      Generate the schema field based on the database type
-    """
-    def type_output (field) do
-        case field do
-            {name, type} when type == :integer -> four_space "field :#{name}, :integer\n"
-            {name, type} when type == :decimal -> four_space "field :#{name}, :decimal\n"
-            {name, type} when type == :float -> four_space  "field :#{name}, :float\n"
-            {name, type} when type == :string -> four_space "field :#{name}, :string\n"
-            {name,type} when type == :date -> four_space "field :#{name}, Ecto.DateTime\n"
-            _ -> ""
-        end
-    end
-
   @doc """
-    Write the given schema to file.
+  Write the given schema to file.
   """
   @spec write(String.t, String.t, String.t) :: Any
   def write(schema, name, path \\ "") do
@@ -25,35 +9,61 @@ defmodule Plsm.IO.Export do
       {_, msg} -> IO.puts "Could not write #{name} to file: #{msg}"
     end
   end
-    
-  @doc """ 
-    Format the text of a specific table with the fields that are passed in. This is strictly formatting and will not verify the fields with the database
+
+  @doc """
+  Format the text of a specific table with the fields that are passed in. This is strictly formatting and will not verify the fields with the database
   """
   @spec prepare(Plsm.Database.Table, String.t) :: String.t
   def prepare(table, project_name) do
-      output = module_declaration(project_name,table.header.name) <> model_inclusion <> primary_key_declaration(table.columns) <> schema_declaration(table.header.name)
-      column_output = table.columns |> Enum.reduce("",fn(x,a) -> a <> type_output({x.name, x.type}) end)
-      output = output <> column_output
-      output = output <> four_space end_declaration
-      output = output <> changeset table.columns
-      output <> end_declaration
+    output = module_declaration(project_name,table.header.name)
+    <> model_inclusion()
+    <> required_columns()
+    <> optional_columns(table.columns)
+    <> primary_key_declaration(table.columns)
+    <> schema_declaration(table.header.name)
+    <> column_output(table.columns)
+    <> two_space end_declaration()
+    <> "\n"
+    <> changeset()
+    output <> end_declaration()
+  end
+
+  defp column_output(columns) do
+    columns
+    |> remove_default_keys()
+    |> Enum.reduce("",fn(x,a) -> a <> type_output({x.name, x.type}) end)
   end
 
   @spec primary_key_declaration([Plsm.Database.Column]) :: String.t
   defp primary_key_declaration(columns) do
-    Enum.reduce(columns, "", fn(x,acc) -> case x.primary_key do 
-        true -> acc <> two_space "@primary_key {:#{x.name}, :#{x.type}, []}\n"
-        _ -> acc
-       end
+    Enum.reduce(columns, "", fn(x,acc) -> case x.primary_key do
+      true ->
+        # As id is a default field, don't add it as the primary_key
+        acc <> if x.name == "id" do
+          ""
+        else
+          two_space "@primary_key {:#{x.name}, :#{x.type}, []}\n"
+        end
+      _ -> acc
+      end
     end)
   end
 
   defp module_declaration(project_name, table_name) do
-    namespace = table_name 
-      |> String.split("_") 
-      |> Enum.map(fn x -> String.capitalize x end)
-      |> Enum.reduce(fn x, acc -> acc <> x end)
-      "defmodule #{project_name}.#{namespace} do\n"
+    namespace = table_name
+    |> String.split("_")
+    |> Enum.map(fn x -> String.capitalize x end)
+    |> Enum.reduce(fn x, acc -> acc <> x end)
+
+    "defmodule #{project_name}.#{namespace} do\n"
+  end
+
+  def optional_columns(columns) do
+    two_space "@optional_fields [" <> changeset_list(columns) <> "]\n\n"
+  end
+
+  def required_columns() do
+    two_space "@required_fields []\n"
   end
 
   defp model_inclusion do
@@ -68,6 +78,35 @@ defmodule Plsm.IO.Export do
     "end\n"
   end
 
+  defp changeset() do
+    two_space "def changeset(struct, params \\\\ %{}) do\n"
+    <> four_space "struct\n"
+    <> four_space "|> cast(params, @required_fields ++ @optional_fields)\n"
+    <> four_space "|> validate_required(params, @required_fields)\n"
+    <> two_space "end\n"
+  end
+
+  defp changeset_list(columns) do
+    columns
+    |> remove_default_keys()
+    |> Enum.reduce("",fn(x,a) -> a <> ":#{x.name}, " end)
+    |> String.trim_trailing(", ")
+  end
+
+  """
+  Generate the schema field based on the database type
+  """
+  defp type_output(field) do
+    case field do
+      {name, type} when type == :integer -> four_space "field :#{name}, :integer\n"
+      {name, type} when type == :decimal -> four_space "field :#{name}, :decimal\n"
+      {name, type} when type == :float -> four_space "field :#{name}, :float\n"
+      {name, type} when type == :string -> four_space "field :#{name}, :string\n"
+      {name,type} when type == :date -> four_space "field :#{name}, Ecto.DateTime\n"
+      _ -> ""
+    end
+  end
+
   defp four_space(text) do
     "    " <> text
   end
@@ -76,15 +115,10 @@ defmodule Plsm.IO.Export do
     "  " <> text
   end
 
-  defp changeset(columns) do
-    output = two_space "def changeset(struct, params \\\\ %{}) do\n"
-    output = output <> four_space "struct\n"
-    output = output <> four_space "|> cast(params, " <> changeset_list(columns) <> ")\n"
-    output <> two_space "end\n"
-  end
-
-  defp changeset_list(columns) do
-    changelist = Enum.reduce(columns,"", fn(x,acc) -> acc <> ":#{x.name}, " end)
-    String.slice(changelist,0,String.length(changelist) - 2)
+  defp remove_default_keys(columns) do
+    columns
+    |> List.delete(%Plsm.Database.Column{name: "id", primary_key: true, type: :integer})
+    |> List.delete(%Plsm.Database.Column{name: "created_at", primary_key: false, type: :date})
+    |> List.delete(%Plsm.Database.Column{name: "updated_at", primary_key: false, type: :date})
   end
 end


### PR DESCRIPTION
Will now generate schema as follows:
```
defmodule Dummy.Example do
  use Ecto.Schema

  @required_fields []
  @optional_fields [:foo, :bar, :baz]

  schema "example" do
    field :foo, :string
    field :bar, :integer
    field :baz, :integer
  end

  def changeset(struct, params \\ %{}) do
    struct
    |> cast(params, @required_fields ++ @optional_fields)
    |> validate_required(params, @required_fields)
  end
end
```

Will no longer pass `:id`/`:created_at`/`:updated_at` keys to the table
for casting, and removes them from the schema.