### PR TITLE
Fixes mysql to output :mysql by default instead of as a string

### DIFF
--- a/lib/plsm.ex
+++ b/lib/plsm.ex
@@ -64,7 +64,7 @@ use Mix.Task
         <> format_item("database_name", "Name of database",",")
         <> format_item("username","username",",")
         <> format_item("password", "password")
-        <> format_atom("type", ":mysql")
+        <> format_atom("type", :mysql)
         <> "\t\t  ]"
     end
 
@@ -72,8 +72,8 @@ use Mix.Task
         "\t\t\t#{name}: \"#{value}\"#{comma}\n"
     end
 
-    defp format_atom(name, value, comma \\ "") do
-      "\t\t\t#{name}: #{value}\n"
+    defp format_atom(name, value, comma \\ "") when is_atom(value) do
+      "\t\t\t#{name}: :#{value}\n"
     end
 end
 defmodule Mix.Tasks.Plasm.Config do


### PR DESCRIPTION
Outputs as:

```
###################################################################################################################################################
# Describes information about the project you are working on. The name will determine what the module name is for each file. Spaces will be removed
###################################################################################################################################################

project = [
			name: "module name",
			destination: "output path"
		  ]

#######################################################################################################################################################
# Enter the database information for the DB you're connecting to. Please note that type is optional and the default is mysql#######################################################################################################################################################

database = [
			server: "localhost",
			port: "3306",
			database_name: "Name of database",
			username: "username",
			password: "password"
			type: :mysql
		  ]
```