### PR TITLE
Changed from bracket to dot syntax for Plsm access to configs.project name and configs.project.destination

### DIFF
--- a/lib/plsm.ex
+++ b/lib/plsm.ex
@@ -17,8 +17,8 @@ defmodule Mix.Tasks.Plsm do
             columns = Plsm.Database.get_columns(header.database, header)
             table = %Plsm.Database.Table {header: header, columns: columns}
 
-            Plsm.IO.Export.prepare(table, configs.project[:name])
-            |> Plsm.IO.Export.write(header.name, configs.project[:destination])
+            Plsm.IO.Export.prepare(table, configs.project.name)
+            |> Plsm.IO.Export.write(header.name, configs.project.destination)
         end
     end
 end


### PR DESCRIPTION
I was getting errors like:
```
** (UndefinedFunctionError) function Plsm.Configs.Project.fetch/2 is undefined (Plsm.Configs.Project does not implement the Access behaviour)
    Plsm.Configs.Project.fetch(%Plsm.Configs.Project{destination: "results", name: "Plsm"}, :name)
    (elixir) lib/access.ex:240: Access.fetch/2
    (elixir) lib/access.ex:269: Access.get/3
    lib/plsm.ex:20: anonymous fn/3 in Mix.Tasks.Plsm.run/1
    (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/plsm.ex:16: Mix.Tasks.Plsm.run/1
    (mix) lib/mix/task.ex:300: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
```

Here's what I'm running:
```
Erlang/OTP 19 [erts-8.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
Interactive Elixir (1.4.4)
```
