### PR TITLE
Fix for exceptions on string split for foreign key table names

### DIFF
--- a/lib/database/structs.ex
+++ b/lib/database/structs.ex
@@ -1,5 +1,5 @@
 defmodule Plsm.Database.Column do
-  defstruct name: String, type: :none, primary_key: false, foreign_table: String, foreign_field: String
+  defstruct name: nil, type: :none, primary_key: false, foreign_table: nil, foreign_field: nil
 end
 
 defmodule Plsm.Database.Table do


### PR DESCRIPTION
I was getting errors like:
```
** (FunctionClauseError) no function clause matching in String.split/3
    (elixir) lib/string.ex:344: String.split(String, "_", [])
    lib/database/structs.ex:14: Plsm.Database.TableHeader.table_name/1
    lib/io/export.ex:101: Plsm.IO.Export.belongs_to_output/2
    lib/io/export.ex:42: anonymous fn/3 in Plsm.IO.Export.prepare/2
    (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/io/export.ex:41: Plsm.IO.Export.prepare/2
    lib/plsm.ex:20: anonymous fn/3 in Mix.Tasks.Plsm.run/1
    (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
```

 I'm pretty sure this is defaulting the value of the strings in the struct to the value of the class String. This gives me errors when if fails a nil ttest plsm.ex and then is tried to be split in table_name inside this same struct file. I am attempting to fix it by initializing these values as nil, like the code seems to expect.

Here's what I'm running:
```
Erlang/OTP 19 [erts-8.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
Interactive Elixir (1.4.4)
```
