### PR TITLE
Corrects syntax to install dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You are able to change the location of the model file output in the configuratio
 
 You can add 
 
-`{:plsm, "=> 2.2.0"}`
+`{:plsm, "~> 2.2.0"}`
 
 to deps in your mix.exs and that will download the package for you
 


### PR DESCRIPTION
Tried using this today and got a syntax error when using `=` instead of `~`.