### PR TITLE
Fix spelling of "formerly"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plsm (Formally Plasm)- Ecto model generation
+# Plsm (Formerly Plasm)- Ecto model generation
 
 Plsm generates Ecto models based on existing database tables in your database. Currently, Ecto only allows the ability to create migrations that creates new tables/schemas. If you have an existing project that you want to add Ecto support for you would have to hand code the models. This can be tedious for tables that have many columns. 
 


### PR DESCRIPTION
Correcting a misspelling in the README.

<dl>
<dt><a href="http://www.dictionary.com/browse/formerly">Formerly</a></dt>
<dd>In the past</dd>
<dt><a href="http://www.dictionary.com/browse/formally">Formally</a></dt>
<dd>In a formal manner</dd>
</dl>