### PR TITLE
`:map` type is recognized but not properly exported

### DIFF
--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -10,6 +10,7 @@ defmodule Plsm.IO.Export do
             {name, type} when type == :float -> four_space  "field :#{name}, :float\n"
             {name, type} when type == :string -> four_space "field :#{name}, :string\n"
             {name, type} when type == :text -> four_space "field :#{name}, :text\n"
+            {name, type} when type == :map -> four_space("field :#{name}, :map\n")
             {name,type} when type == :date -> four_space "field :#{name}, :naive_datetime\n"
             _ -> ""
         end


### PR DESCRIPTION
When experimenting with our existing database I noticed that `jsonb` columns are recognized by default but not exported into the `schema` definition.