### PR TITLE
Update mysql.ex: use backticks around table name

### DIFF
--- a/lib/database/mysql.ex
+++ b/lib/database/mysql.ex
@@ -56,7 +56,7 @@ defimpl Plsm.Database, for: Plsm.Database.MySql do
 
   @spec get_columns(Plsm.Database.MySql, Plsm.Database.Table) :: [Plsm.Database.Column]
   def get_columns(db, table) do
-    {_, result} = Mariaex.query(db.connection, "show columns from #{table.name}")
+    {_, result} = Mariaex.query(db.connection, "show columns from `#{table.name}`")
 
     result.rows
     |> Enum.map(&to_column/1)


### PR DESCRIPTION
I ran this code on a database which includes a table called "match" and the sql generated is invalid. By adding the back ticks it ensures the table name is recognised correctly and the SQL statement is valid.