### PR TITLE
Column whitespace fix

### DIFF
--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -2,30 +2,33 @@ defmodule Plsm.IO.Export do
   @doc """
     Generate the schema field based on the database type
   """
-  def type_output(field) do
-    case field do
-      {name, type, is_primary_key?} when type == :decimal ->
-        four_space("field :#{name}, :decimal, :primary_key #{is_primary_key?}\n")
 
-      {name, type, is_primary_key?} when type == :float ->
-        four_space("field :#{name}, :float, :primary_key #{is_primary_key?}\n")
+  def type_output({name, type, is_primary_key?}) do
+    escaped_name = escaped_name(name)
 
-      {name, type, is_primary_key?} when type == :string ->
-        four_space("field :#{name}, :string, :primary_key #{is_primary_key?}\n")
-
-      {name, type, is_primary_key?} when type == :text ->
-        four_space("field :#{name}, :string, :primary_key #{is_primary_key?}\n")
-
-      {name, type, is_primary_key?} when type == :map ->
-        four_space("field :#{name}, :map, :primary_key #{is_primary_key?}\n")
-
-      {name, type, is_primary_key?} when type == :date ->
-        four_space("field :#{name}, :naive_datetime, :primary_key #{is_primary_key?}\n")
-
-      _ ->
-        ""
-    end
+    type_output_with_source(escaped_name, name, map_type(type), is_primary_key?)
+    |> four_space()
   end
+
+  defp map_type(:decimal), do: ":decimal"
+  defp map_type(:float), do: ":float"
+  defp map_type(:string), do: ":string"
+  defp map_type(:text), do: ":string"
+  defp map_type(:map), do: ":map"
+  defp map_type(:date), do: ":naive_datetime"
+
+  @doc """
+  When escaped name and name are the same, source option is not needed
+  """
+  defp type_output_with_source(escaped_name, escaped_name, mapped_type, is_primary_key?),
+    do: "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}\n"
+
+  @doc """
+  When escaped name and name are different, add a source option poitning to the original field name as an atom
+  """
+  defp type_output_with_source(escaped_name, name, mapped_type, is_primary_key?),
+    do:
+      "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}, source: :\"#{name}\"\n"
 
   @doc """
     Write the given schema to file.
@@ -56,7 +59,9 @@ defmodule Plsm.IO.Export do
 
     column_output =
       trimmed_columns
-      |> Enum.reduce("", fn x, a -> a <> type_output({x.name, x.type, x.primary_key}) end)
+      |> Enum.reduce("", fn column, a ->
+        a <> type_output({column.name, column.type, column.primary_key})
+      end)
 
     output = output <> column_output
 
@@ -110,7 +115,7 @@ defmodule Plsm.IO.Export do
 
   defp changeset_list(columns) do
     columns
-    |> Enum.map(fn c -> ":#{c.name}" end)
+    |> Enum.map(fn c -> ":#{escaped_name(c.name)}" end)
     |> Enum.join(", ")
   end
 
@@ -125,5 +130,10 @@ defmodule Plsm.IO.Export do
     Enum.filter(columns, fn column ->
       column.foreign_table == nil and column.foreign_field == nil
     end)
+  end
+
+  defp escaped_name(name) do
+    name
+    |> String.replace(" ", "_")
   end
 end


### PR DESCRIPTION
Fixing case when a field in the database view contains whitespace which results in an invalid column name. Example:

```sql
CREATE VIEW staff_list AS
 SELECT s.staff_id AS id,
    (((s.first_name)::text || ' '::text) || (s.last_name)::text) AS name,
    a.address,
    a.postal_code AS "zip code",
    a.phone,
    city.city,
    country.country,
    s.store_id AS sid
   FROM (((staff s
     JOIN address a ON ((s.address_id = a.address_id)))
     JOIN city ON ((a.city_id = city.city_id)))
     JOIN country ON ((city.country_id = country.country_id)));
```

This results in:

```elixir
field :zip code, :string, primary_key: false
```

Uncovered by #107 