### PR TITLE
More type to Ecto conversions

### DIFF
--- a/lib/database/postgresql.ex
+++ b/lib/database/postgresql.ex
@@ -98,7 +98,7 @@ defimpl Plsm.Database, for: Plsm.Database.PostgreSQL do
         AND pg_table_is_visible(pgc.oid)
         AND NOT a.attisdropped
         AND pgc.relname = '#{table.name}'
-        ORDER BY a.attnum;", [])
+        ORDER BY a.attname;", [])
 
     result.rows
     |> Enum.map(&to_column/1)

--- a/lib/database/postgresql.ex
+++ b/lib/database/postgresql.ex
@@ -127,17 +127,20 @@ defimpl Plsm.Database, for: Plsm.Database.PostgreSQL do
     cond do
       String.starts_with?(upcase, "INTEGER") == true -> :integer
       String.starts_with?(upcase, "INT") == true -> :integer
+      String.starts_with?(upcase, "SMALLINT") == true -> :integer
       String.starts_with?(upcase, "BIGINT") == true -> :integer
-      String.contains?(upcase, "CHAR") == true -> :string
+      String.starts_with?(upcase, "CHAR") == true -> :string
       String.starts_with?(upcase, "TEXT") == true -> :string
       String.starts_with?(upcase, "FLOAT") == true -> :float
       String.starts_with?(upcase, "DOUBLE") == true -> :float
       String.starts_with?(upcase, "DECIMAL") == true -> :decimal
       String.starts_with?(upcase, "NUMERIC") == true -> :decimal
+      String.starts_with?(upcase, "JSON") == true -> :map
       String.starts_with?(upcase, "JSONB") == true -> :map
       String.starts_with?(upcase, "DATE") == true -> :date
-      String.starts_with?(upcase, "DATETIME") == true -> :date
-      String.starts_with?(upcase, "TIMESTAMP") == true -> :date
+      String.starts_with?(upcase, "DATETIME") == true -> :timestamp
+      String.starts_with?(upcase, "TIMESTAMP") == true -> :timestamp
+      String.starts_with?(upcase, "TIME") == true -> :time
       String.starts_with?(upcase, "BOOLEAN") == true -> :boolean
       true -> :none
     end

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -56,7 +56,9 @@ defmodule Plsm.IO.Export do
   def prepare(table, project_name) do
     output =
       module_declaration(project_name, table.header.name) <>
-        model_inclusion() <> schema_declaration(table.header.name)
+        model_inclusion() <>
+        primary_key_disable() <>
+        schema_declaration(table.header.name)
 
     trimmed_columns = remove_foreign_keys(table.columns)
 
@@ -91,6 +93,10 @@ defmodule Plsm.IO.Export do
 
   defp model_inclusion do
     two_space("use Ecto.Schema\n" <> two_space("import Ecto.Changeset\n\n"))
+  end
+
+  defp primary_key_disable do
+    two_space("@primary_key false\n")
   end
 
   defp schema_declaration(table_name) do

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -9,12 +9,15 @@ defmodule Plsm.IO.Export do
     |> four_space()
   end
 
+  defp map_type(:boolean), do: ":boolean"
   defp map_type(:decimal), do: ":decimal"
   defp map_type(:float), do: ":float"
   defp map_type(:string), do: ":string"
   defp map_type(:text), do: ":string"
   defp map_type(:map), do: ":map"
-  defp map_type(:date), do: ":naive_datetime"
+  defp map_type(:date), do: ":date"
+  defp map_type(:time), do: ":time"
+  defp map_type(:timestamp), do: ":naive_datetime"
   defp map_type(:integer), do: ":integer"
 
   @doc """


### PR DESCRIPTION
Hi Jon Hartwell,

I found your library very useful as I have a big database that I wanted to use Elixir/Phoenix/Ecto on!

While generating the Schema's I came across some points that prevented me from using the Schema's right away,
this Pull Request is my attempt to improve upon your great library.

For example, several of the database tables have columns of over 100 fields, I found it helpful to sort the Schema by column name, however maybe users should have a config option to define what they would like?

When generating the Schema's, all Date's would fail that were not just only Dates, therefor I've refined this in the Postgres/Export lib files.

And the final thing preventing me from using the Schema's was the default Primary Key of id (integer), since for most of the tables this is set to a different column, type and/or field.

The one thing I couldn't quickly change was composite primary key's.
Here is a query for PostgreSQL that lists all the composite key tables:
```
with composite_constraint_tables as (
    select table_name, count(column_name)
    from information_schema.key_column_usage
    where constraint_schema = 'public'
    group by table_name
    having count(column_name) > 1
)
select table_name, column_name
from information_schema.key_column_usage
where constraint_schema = 'public'
and table_name in (select table_name from composite_constraint_tables)
order by constraint_name;
```

Hopefully you agree on the proposed changes or just pick the ones that make sense to you.

Thank you,
Patrick