### PR TITLE
Improve MySQL support and export module.

### DIFF
--- a/lib/database/mysql.ex
+++ b/lib/database/mysql.ex
@@ -76,20 +76,35 @@ defimpl Plsm.Database, for: Plsm.Database.MySql do
     downcase = String.downcase(type)
 
     cond do
-      String.starts_with?(downcase, "int") -> :integer
-      String.starts_with?(downcase, "bigint") -> :integer
       String.starts_with?(downcase, "tinyint(1)") -> :boolean
-      String.starts_with?(downcase, "tinyint") -> :integer
-      String.starts_with?(downcase, "bit") -> :integer
-      String.contains?(downcase, "char") -> :string
-      String.starts_with?(downcase, "text") -> :string
-      String.starts_with?(downcase, "float") -> :float
-      String.starts_with?(downcase, "double") -> :float
-      String.starts_with?(downcase, "decimal") -> :decimal
-      String.starts_with?(downcase, "date") -> :date
-      String.starts_with?(downcase, "datetime") -> :date
-      String.starts_with?(downcase, "timestamp") -> :date
-      String.starts_with?(downcase, "smallint") -> :integer
+      String.starts_with?(downcase, "tinyint")    -> :integer
+      String.starts_with?(downcase, "smallint")   -> :integer
+      String.starts_with?(downcase, "mediumint")  -> :integer
+      String.starts_with?(downcase, "int")        -> :integer
+      String.starts_with?(downcase, "bigint")     -> :integer
+      String.starts_with?(downcase, "float")      -> :float
+      String.starts_with?(downcase, "double")     -> :float
+      String.starts_with?(downcase, "decimal")    -> :decimal
+      String.starts_with?(downcase, "numeric")    -> :decimal
+      String.starts_with?(downcase, "date")       -> :date
+      String.starts_with?(downcase, "time")       -> :time
+      String.starts_with?(downcase, "year")       -> :date
+      String.starts_with?(downcase, "datetime")   -> :utc_datetime
+      String.starts_with?(downcase, "timestamp")  -> :utc_datetime
+      String.starts_with?(downcase, "bit(1)")     -> :boolean
+      String.starts_with?(downcase, "bit")        -> :binary
+      String.starts_with?(downcase, "binary")     -> :binary      
+      String.starts_with?(downcase, "varbinary")  -> :binary
+      String.starts_with?(downcase, "tinyblob")   -> :binary
+      String.starts_with?(downcase, "blob")       -> :binary
+      String.starts_with?(downcase, "mediumblob") -> :binary
+      String.starts_with?(downcase, "longblob")   -> :binary
+      String.starts_with?(downcase, "char")       -> :string
+      String.starts_with?(downcase, "varchar")    -> :string
+      String.starts_with?(downcase, "tinytext")   -> :string
+      String.starts_with?(downcase, "text")       -> :string
+      String.starts_with?(downcase, "mediumtext") -> :string
+      String.starts_with?(downcase, "longtext")   -> :string
       true -> :none
     end
   end

--- a/lib/database/mysql.ex
+++ b/lib/database/mysql.ex
@@ -108,6 +108,7 @@ defimpl Plsm.Database, for: Plsm.Database.MySql do
       String.starts_with?(downcase, "text")       -> :string
       String.starts_with?(downcase, "mediumtext") -> :string
       String.starts_with?(downcase, "longtext")   -> :string
+      String.starts_with?(downcase, "json")       -> :map
       true -> :none
     end
   end

--- a/lib/database/mysql.ex
+++ b/lib/database/mysql.ex
@@ -88,9 +88,9 @@ defimpl Plsm.Database, for: Plsm.Database.MySql do
       String.starts_with?(downcase, "numeric")    -> :decimal
       String.starts_with?(downcase, "date")       -> :date
       String.starts_with?(downcase, "time")       -> :time
-      String.starts_with?(downcase, "year")       -> :date
-      String.starts_with?(downcase, "datetime")   -> :utc_datetime
-      String.starts_with?(downcase, "timestamp")  -> :utc_datetime
+      String.starts_with?(downcase, "year")       -> :date  # integer?
+      String.starts_with?(downcase, "datetime")   -> :datetime
+      String.starts_with?(downcase, "timestamp")  -> :timestamp
       String.starts_with?(downcase, "bit(1)")     -> :boolean
       String.starts_with?(downcase, "bit")        -> :binary
       String.starts_with?(downcase, "binary")     -> :binary      

--- a/lib/database/mysql.ex
+++ b/lib/database/mysql.ex
@@ -65,15 +65,16 @@ defimpl Plsm.Database, for: Plsm.Database.MySql do
 
   defp to_column(row) do
     {_, name} = Enum.fetch(row, 0)
-    type = Enum.fetch(row, 1) |> get_type
-    {_, pk} = Enum.fetch(row, 3)
-    primary_key? = pk == "PRI"
-    %Plsm.Database.Column{name: name, type: type, primary_key: primary_key?}
+    {_, type} = Enum.fetch(row, 1)
+    {_, prik} = Enum.fetch(row, 3)
+
+    pkey = (prik == "PRI")
+
+    %Plsm.Database.Column{name: name, type: trans_type(type), primary_key: pkey, db_type: type}
   end
 
-  defp get_type(start_type) do
-    {_, type} = start_type
-    downcase = String.downcase(type)
+  defp trans_type(db_type) do
+    downcase = String.downcase(db_type)
 
     cond do
       String.starts_with?(downcase, "tinyint(1)") -> :boolean

--- a/lib/database/mysql.ex
+++ b/lib/database/mysql.ex
@@ -9,8 +9,8 @@ end
 
 defimpl Plsm.Database, for: Plsm.Database.MySql do
   @doc """
-    Create a MySql database struct for use in connecting to the MySql database. We pass in the configs in order to 
-    properly connect
+    Create a MySql database struct for use in connecting to the MySql database.
+    We pass in the configs in order to properly connect
   """
   @spec create(Plsm.Database.MySql, Plsm.Configs) :: Plsm.Database.MySql
   def create(_db, configs) do
@@ -45,7 +45,8 @@ defimpl Plsm.Database, for: Plsm.Database.MySql do
     }
   end
 
-  # pass in a database and then get the tables using the mariaex query then turn the rows into a table
+  # Pass in a database and then get the tables using the `SHOW TABLES` query,
+  # then turn the rows into a table.
   @spec get_tables(Plsm.Database.MySql) :: [Plsm.Database.TableHeader]
   def get_tables(db) do
     {_, result} = MyXQL.query(db.connection, "SHOW TABLES")
@@ -73,6 +74,7 @@ defimpl Plsm.Database, for: Plsm.Database.MySql do
     %Plsm.Database.Column{name: name, type: trans_type(type), primary_key: pkey, db_type: type}
   end
 
+  # Intermediate type designation. The Export module determines the final ecto type.
   defp trans_type(db_type) do
     downcase = String.downcase(db_type)
 

--- a/lib/database/structs.ex
+++ b/lib/database/structs.ex
@@ -1,5 +1,5 @@
 defmodule Plsm.Database.Column do
-  defstruct name: nil, type: :none, primary_key: false, foreign_table: nil, foreign_field: nil
+  defstruct name: nil, type: :none, primary_key: false, foreign_table: nil, foreign_field: nil, db_type: nil
 end
 
 defmodule Plsm.Database.Table do

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -75,7 +75,7 @@ defmodule Plsm.IO.Export do
         primary_key_disable() <>
         schema_declaration(table.header.name)
 
-    warn_unknown_types(table, table.columns)
+    warn_unknown_types(table)
     
     trimmed_columns = remove_foreign_keys(table.columns)
 
@@ -162,10 +162,10 @@ defmodule Plsm.IO.Export do
     end)
   end
 
-  defp warn_unknown_types(table, columns) do
-    Enum.each(columns, fn column ->
+  defp warn_unknown_types(table) do
+    Enum.each(table.columns, fn column ->
       if column.type == :none do
-        IO.puts :stderr, "#{table.header.name} #{column.name} has an unknown type."
+        IO.puts :stderr, "#{column.name} in the #{table.header.name} table has an unsupported type of #{column.db_type}."
       end
     end)
   end

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -31,22 +31,22 @@ defmodule Plsm.IO.Export do
   defp map_type(t),          do: ":#{t}"
   
   # When escaped name and name are the same, source option is not needed
-  defp type_output_with_source(escaped_name, escaped_name, mapped_type, is_primary_key?),
-    do: 
-      if id_primary_key? do
-        "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}\n"
-      else
-        "field :#{escaped_name}, #{mapped_type}\n"
-      end
-
+  defp type_output_with_source(escaped_name, escaped_name, mapped_type, is_primary_key?) do
+    if is_primary_key? do
+      "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}\n"
+    else
+      "field :#{escaped_name}, #{mapped_type}\n"
+    end
+  end
+  
   # When escaped name and name are different, add a source option poitning to the original field name as an atom
-  defp type_output_with_source(escaped_name, name, mapped_type, is_primary_key?),
-    do:
-      if id_primary_key? do
-        "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}, source: :\"#{name}\"\n"
-      else
-        "field :#{escaped_name}, #{mapped_type}, source: :\"#{name}\"\n"
-      end
+  defp type_output_with_source(escaped_name, name, mapped_type, is_primary_key?) do
+    if is_primary_key? do
+      "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}, source: :\"#{name}\"\n"
+    else
+      "field :#{escaped_name}, #{mapped_type}, source: :\"#{name}\"\n"
+    end
+  end
 
   @doc """
     Write the given schema to file.

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -122,7 +122,7 @@ defmodule Plsm.IO.Export do
   end
 
   defp four_space_comment(text) do
-    "    -- " <> text
+    "    # " <> text
   end
 
   defp four_space(text) do

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -31,12 +31,21 @@ defmodule Plsm.IO.Export do
   
   # When escaped name and name are the same, source option is not needed
   defp type_output_with_source(escaped_name, escaped_name, mapped_type, is_primary_key?),
-    do: "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}\n"
+    do: 
+      if id_primary_key? do
+        "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}\n"
+      else
+        "field :#{escaped_name}, #{mapped_type}\n"
+      end
 
   # When escaped name and name are different, add a source option poitning to the original field name as an atom
   defp type_output_with_source(escaped_name, name, mapped_type, is_primary_key?),
     do:
-      "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}, source: :\"#{name}\"\n"
+      if id_primary_key? do
+        "field :#{escaped_name}, #{mapped_type}, primary_key: #{is_primary_key?}, source: :\"#{name}\"\n"
+      else
+        "field :#{escaped_name}, #{mapped_type}, source: :\"#{name}\"\n"
+      end
 
   @doc """
     Write the given schema to file.

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -1,5 +1,20 @@
 defmodule Plsm.IO.Export do
   @doc """
+    Ignore fields with unknow database type.
+    
+    TODO: Would be better to moves this up the call-chain so
+          it can print which table and field it belongs.
+  """
+  def type_output({name, :none, is_primary_key?}) do
+    escaped_name = escaped_name(name)
+    
+    IO.puts :stderr, "#{name} has an unknown type."
+    
+    type_output_with_source(escaped_name, name, map_type(type), is_primary_key?)
+    |> four_space_comment()
+  end
+
+  @doc """
     Generate the schema field based on the database type
   """
   def type_output({name, type, is_primary_key?}) do
@@ -19,7 +34,8 @@ defmodule Plsm.IO.Export do
   defp map_type(:time), do: ":time"
   defp map_type(:timestamp), do: ":naive_datetime"
   defp map_type(:integer), do: ":integer"
-
+  drfp map_type(t), do: ":#{t}"
+  
   @doc """
   When escaped name and name are the same, source option is not needed
   """
@@ -105,6 +121,10 @@ defmodule Plsm.IO.Export do
 
   defp end_declaration do
     "end\n"
+  end
+
+  defp four_space_comment(text) do
+    "    -- " <> text
   end
 
   defp four_space(text) do

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -1,22 +1,20 @@
 defmodule Plsm.IO.Export do
   @doc """
-    Ignore fields with unknow database type.
+    Generate the schema field based on the database type.
+    But comment out fields with unknown database type.
     
-    TODO: Would be better to moves this up the call-chain so
-          it can print which table and field it belongs.
+    TODO: Would be better to move error ouput up the call-chain
+          so it can print which table and field it belongs.
   """
   def type_output({name, :none, is_primary_key?}) do
     escaped_name = escaped_name(name)
     
     IO.puts :stderr, "#{name} has an unknown type."
     
-    type_output_with_source(escaped_name, name, map_type(type), is_primary_key?)
+    type_output_with_source(escaped_name, name, ":???", is_primary_key?)
     |> four_space_comment()
   end
 
-  @doc """
-    Generate the schema field based on the database type
-  """
   def type_output({name, type, is_primary_key?}) do
     escaped_name = escaped_name(name)
 

--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -17,17 +17,18 @@ defmodule Plsm.IO.Export do
     |> four_space()
   end
 
-  defp map_type(:boolean), do: ":boolean"
-  defp map_type(:decimal), do: ":decimal"
-  defp map_type(:float), do: ":float"
-  defp map_type(:string), do: ":string"
-  defp map_type(:text), do: ":string"
-  defp map_type(:map), do: ":map"
-  defp map_type(:date), do: ":date"
-  defp map_type(:time), do: ":time"
+  defp map_type(:boolean),   do: ":boolean"
+  defp map_type(:decimal),   do: ":decimal"
+  defp map_type(:float),     do: ":float"
+  defp map_type(:string),    do: ":string"
+  defp map_type(:text),      do: ":string"
+  defp map_type(:map),       do: ":map"
+  defp map_type(:date),      do: ":date"
+  defp map_type(:time),      do: ":time"
+  defp map_type(:datetime),  do: ":naive_datetime"
   defp map_type(:timestamp), do: ":naive_datetime"
-  defp map_type(:integer), do: ":integer"
-  defp map_type(t), do: ":#{t}"
+  defp map_type(:integer),   do: ":integer"
+  defp map_type(t),          do: ":#{t}"
   
   # When escaped name and name are the same, source option is not needed
   defp type_output_with_source(escaped_name, escaped_name, mapped_type, is_primary_key?),


### PR DESCRIPTION
I added most of the types that MySQL supports (all the ones that are straight forward).

I also made the Export module a little more resilient. If a type is `:none` then it will still output the column but as a _comment_ with `:???` as the type. Maybe it should not output anything, but at least this way it would be easy to go back and find where fixes are needed by hand.

(Sorry about the four commits, not fully setup here yet so I had to do all this via the web.)